### PR TITLE
opm-core installation & troubleshooting doc updates

### DIFF
--- a/general/common_problems.rst
+++ b/general/common_problems.rst
@@ -7,10 +7,10 @@ Are there perfdata generated?
 -----------------------------
 
 On the Nagios server, check if perfdata are generated.  The location is defined
-in the **proces-service-perfdata-file** and **proces-host-perfdata-file**
+in the ``proces-service-perfdata-file`` and ``proces-host-perfdata-file``
 commands on Nagios, as seen in :ref:`nagios_and_nagios_dispatcher` section.
 
-Assuming default configuration (**/var/lib/nagios3/spool/perfdata/**), you can
+Assuming default configuration (``/var/lib/nagios3/spool/perfdata/``), you can
 check like this::
 
     # ls -al /var/lib/nagios3/spool/perfdata/
@@ -20,10 +20,10 @@ check like this::
   Obviously, you need to have configured Nagios so that checks are actually
   performed to expect perfdata generated.
 
-If files are getting created, you can see next item. Otherwise, you need to
-configure Nagios so perfdata are processed, are documented in
-:ref:`nagios_and_nagios_dispatcher`. Also be careful, if the nagios_dispatcher
-is running, perfdata file won't stay long in the perfdata directory.
+If files are getting created, you can skip to the next item. Otherwise, you need to
+configure Nagios so perfdata are processed, as documented in
+:ref:`nagios_and_nagios_dispatcher`. Also be careful, if the ``nagios_dispatcher``
+is running, perfdata files won't stay long in the perfdata directory.
 
 Is nagios_dispatcher running?
 -----------------------------
@@ -48,6 +48,9 @@ the :ref:`nagios dispatcher <nagios_dispatcher>`:
 
 * check the nagios dispatcher logs
 
+* beware: ``debug=1`` in the dispatcher configuration file will make it stop
+at the first problem in the data.
+
 When the perfdata are being removed from the perfdata directory, you can move
 to the next item.
 
@@ -55,7 +58,7 @@ Are the perfdata accumulating in the hub table?
 -----------------------------------------------
 
 If the nagios_dispatcher is running and perfdata files being removed, lines
-should be added in the **wh_nagios.hub** table of the **opm** database::
+should be added in the ``wh_nagios.hub`` table of the ``opm`` database::
 
   opm=# SELECT COUNT(*) FROM wh_nagios.hub;
 
@@ -64,11 +67,11 @@ should be added in the **wh_nagios.hub** table of the **opm** database::
   If you don't see any line appearing in this table, it's very likely that
   you're looking at the wrong server and/or the wrong database.
 
-According to the :ref:`wh_nagios` documenatation, you should have setup a cron
-to call the **wh_nagios.dispatch_record()** stored function every minute.
+According to the :ref:`wh_nagios` documentation, you should have setup a cron
+to call the ``wh_nagios.dispatch_record()`` stored function every minute.
 
-If after some minutes the number of record doesn't fall, there's a problem with
-this cron. Make sure to double check:
+If after some minutes the number of records doesn't fall, there's a problem with
+this cron. Make sure to double check::
 
 * output of this cron if you redirected it to a file or a mail
 * credential access (you can use a `.pgpass file
@@ -79,8 +82,8 @@ this cron. Make sure to double check:
     * PostgreSQL logs
     * pg_hba and/or credentials
 
-Once the **wh_nagios.dispatch_record()** is successfully called, the data will
-arrive in the user tables. You can check for instance the number of servers the
+Once the ``wh_nagios.dispatch_record()`` is successfully called, the data will
+appear in the user tables. You can check for instance the number of servers the
 UI knows about::
 
     opm=# SELECT COUNT(*) FROM public.servers;
@@ -96,8 +99,8 @@ I still can't see anything in the UI
     * PostgreSQL logs
     * pg_hba and/or credentials
 
-* check the UI logs.  For instance, if you used aN
-  :ref:`Apache server<ui_apache>`, the opm.log.  If you tried with the
+* check the UI logs.  For instance, if you used an
+  :ref:`Apache server<ui_apache>`, the ``opm.log``.  If you tried with the
   :ref:`morbo tool<ui_morbo>`, then the standard output.
-* check that you connect to the good OPM UI server
+* check that you connect to the good OPM UI server.
 


### PR DESCRIPTION
Documentation updates:

- a few typos and formulations, a bit of formatting
- some more details that I think would be important for someone installing OPM without knowing much about nagios, PG extensions, OPM itself, like distribution packages
- a few traps I fell in :-)
- changed "user1"  name and the identical similar password
- changed daemon=0 in the configuration file for systemd (it does not work with =1 on my setup - btw, does it with inittab or upstart ??) ; 
- in same file, I've kept only the lines different from above
- added a warning that debug=1 stops the process when there is a problem (that's unexpected)
