### PR TITLE
Add a backup page, due to problems with parallelized restore

### DIFF
--- a/general/getting_started.rst
+++ b/general/getting_started.rst
@@ -27,3 +27,6 @@ See the :doc:`Installation <../opm-core/Installation>` page to install:
   * the :ref:`nagios dispatcher script<nagios_and_nagios_dispatcher>` to
     retrieve the perfdata
   * the :ref:`web user interface <user_interface>`.
+
+When preparing your backup and restoration procedures,
+see :doc:`Backups <../opm-core/Backups>`.

--- a/opm-core/Backups.rst
+++ b/opm-core/Backups.rst
@@ -1,0 +1,22 @@
+Backups
+=======
+
+Usual backup procedures apply. The procedure should include the way to reinstall the extensions on a virgin server.
+
+Restoring logical backups
+-------------------------
+
+In a general way, restoring a backup created with pg_dump should not be a problem as the backup contains the necessary `CREATE EXTENSION` orders. The extension binaries must be present.
+
+You may wish to parallelize the restoration to spare time. In this case, it may fail with a foreign key error, as the extensions install tables with foreign keys at the very beginning of the restore, and pg_restore does not try to respect this order. The trick is to parallelize only the restoration of the biggest tables.
+
+The following commands assume that the database and the roles were already created :
+
+.. code-block:: bash
+
+    pg_restore -e --section=pre-data -d opm  opm.dump
+    pg_restore -e --section=data -l opm.dump|grep -v 'service_counters_' > restore.1.list
+    pg_restore -e --section=data -l opm.dump|grep  'service_counters_' > restore.2.list
+    pg_restore -e -d opm  -L restore.1.list opm.dump
+    pg_restore -e -d opm  -L restore.2.list opm.dump  --jobs=4
+    pg_restore -e --section=post-data -d opm  opm.dump --jobs=4


### PR DESCRIPTION
A parallelized logical restore may fail, as seen in #16. Add the procedure. Add a Backups page and some generalities as there was none.